### PR TITLE
Add a function that removes a user from the previous team

### DIFF
--- a/rocketc/api_rocket_chat.py
+++ b/rocketc/api_rocket_chat.py
@@ -197,3 +197,12 @@ class ApiRocketChat(object):
         LOG.info("Method Update User: %s with this data: %s", response, data)
         if response["success"]:
             return email
+
+    def kick_user_from_group(self, user_id, room_id):
+        """
+        Removes a user from the private group.
+        """
+        url_path = "groups.kick"
+        data = {"roomId": room_id, "userId": user_id}
+        response = self._request_rocket_chat("post", url_path, data)
+        LOG.info("Method Kick user from a Group: %s with this data: %s", response, data)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.2.7
+current_version = 0.2.8
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import os
 
 from setuptools import setup
 
-__version__ = '0.2.7'
+__version__ = '0.2.8'
 
 
 def package_data(pkg, roots):


### PR DESCRIPTION
## Description
These changes removes a user from a rocketchat team channel  if  the user is currently in other team or if the user is not in a team (These comparisons are made with the previous user team)

## Reviewers

- [x] @diegomillan 
- [ ] @jfavellar90  