### PR TITLE
Add support to remove from all team's chats

### DIFF
--- a/rocketc/api_rocket_chat.py
+++ b/rocketc/api_rocket_chat.py
@@ -208,10 +208,10 @@ class ApiRocketChat(object):
         LOG.info("Method Kick user from a Group: %s with this data: %s", response, data)
         return response
 
-    def list_all_groups(self, user_id, auth_token, query=""):
+    def list_all_groups(self, user_id, auth_token, **kwargs):
         """Get a list of groups"""
         url_path = "groups.list"
-        payload = {"query": query}
+        payload = kwargs
         url = "/".join([self.server_url, self.API_PATH, url_path])
 
         headers = {"X-User-Id": user_id, "X-Auth-Token": auth_token}

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.2.17
+current_version = 0.2.18
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import os
 
 from setuptools import setup
 
-__version__ = '0.2.17'
+__version__ = '0.2.18'
 
 
 def package_data(pkg, roots):


### PR DESCRIPTION
## Description 
When you are a team member and another user creates a new chat all the team members will be added to that chat, currently if you leave or you are removed from the team, you only leave the main chat, with theses changes when a user leaves a team, the user will be removed from all custom chats and main chat.
When a user creates a new chat this will call "team_id-team_name-newName", then the xblock find all the chats with "team_id-team_name" like a part of its name and removes the user from those.
## Reviewers 
- [x] @jfavellar90 
- [ ] @diegomillan 
