### PR TITLE
PE 14 Allow staff to create and embed a new team channel in studio

### DIFF
--- a/rocketc/api_teams.py
+++ b/rocketc/api_teams.py
@@ -4,49 +4,46 @@ Api for teams
 import os
 import logging
 import requests
-from oauthlib.oauth2 import LegacyApplicationClient
+from oauthlib.oauth2 import BackendApplicationClient
 from requests_oauthlib import OAuth2Session
 
 LOG = logging.getLogger(__name__)
 os.environ['OAUTHLIB_INSECURE_TRANSPORT'] = '1'
 
 
-class ApiTeams(object):  #pylint: disable=too-few-public-methods
+class ApiTeams(object):  # pylint: disable=too-few-public-methods
 
-    headers = {}
     API_PATH = 'api/team/v0'
 
-    def __init__(self, username, password, client_id, client_secret,  # pylint: disable=too-many-arguments
+    def __init__(self, client_id, client_secret,  # pylint: disable=too-many-arguments
                  server_url='http://127.0.0.1:8000'):
         """Creates a ApiTeams object"""
         self.server_url = server_url
-        self.client_id = client_id
-        self.client_secret = client_secret
-        self.password = password
-        self.username = username
-        self.headers["Authorization"] = "{} {}".format(
-            "Bearer", self._get_token(server_url))
+        self. session = self._init_session(server_url, client_id, client_secret)
 
-    def _get_token(self, server_url):
+    @staticmethod
+    def _init_session(server_url, client_id, client_secret):
         """This method get the Authorization token"""
-        oauth = OAuth2Session(
-            client=LegacyApplicationClient(client_id=self.client_id))
+        client = BackendApplicationClient(client_id=client_id)
+        oauth = OAuth2Session(client=client)
         token_url = "/".join([server_url, "oauth2/access_token/"])
+        headers = {}
 
         token = oauth.fetch_token(token_url=token_url,
-                                  client_id=self.client_id,
-                                  client_secret=self.client_secret,
-                                  username=self.username,
-                                  password=self.password)
+                                  client_id=client_id,
+                                  client_secret=client_secret
+                                 )
 
-        LOG.info("The acces token is: %s", token["access_token"])
-
-        return token['access_token']
+        headers["Authorization"] = "{} {}".format(
+            "Bearer", token['access_token'])
+        session = requests.Session()
+        session.headers.update(headers)
+        return session
 
     def _call_api_get(self, url_path, payload=None):
         """This method return the response"""
         url = "/".join([self.server_url, self.API_PATH, url_path])
-        return requests.get(url, headers=self.headers, params=payload)
+        return self.session.get(url, params=payload)
 
     def get_user_team(self, course_id, username):
         """Get the user's team"""
@@ -70,5 +67,18 @@ class ApiTeams(object):  #pylint: disable=too-few-public-methods
         if team_request.status_code == 200:
             return team_request.json()["results"]
         LOG.error("An error has ocurred trying to fetch team members with status code = %s",
+                  team_request.status_code)
+        return None
+
+    def get_course_teams(self, course_id):
+        """Get the user's team"""
+        course_id = course_id.to_deprecated_string()
+        url_path = "teams"
+        payload = {"course_id": course_id}
+        team_request = self._call_api_get(url_path, payload)
+
+        if team_request.status_code == 200:
+            return team_request.json()["results"]
+        LOG.error("An error has ocurred trying to get the user with status code = %s",
                   team_request.status_code)
         return None

--- a/rocketc/static/html/rocketc.html
+++ b/rocketc/static/html/rocketc.html
@@ -4,9 +4,9 @@
             {% if "authToken" in response %}
                 <div class="embed-container">
                     <iframe style="width:0;height:0;border:0; border:none;" src="{{public_url_service}}/home?authToken={{response.authToken}}&userId={{response.userId}}" >IFrame is not supported</iframe>
-                    <iframe id="myframe" src="{{public_url_service}}/group/{{user_data.default_group}}?layout=embedded" >IFrame is not supported</iframe>
+                    <iframe id="myframe" src="{{public_url_service}}/group/{{response.default_group}}?layout=embedded" >IFrame is not supported</iframe>
                  </div>
-                <div id="tool-buttons" data-domain="{{public_url_service}}/group/" data-user-id="{{response.userId}}" data-token="{{response.authToken}}" data-default="{{user_data.default_group}}">
+                <div id="tool-buttons" data-domain="{{public_url_service}}/group/" data-user-id="{{response.userId}}" data-token="{{response.authToken}}" data-default="{{response.default_group}}">
                     <div>
                         <a class="button" id="create-channel">Create New Team Chat</a>
                         <a class="button" id="leave-channel">Leave Chat</a>

--- a/rocketc/static/html/studio.html
+++ b/rocketc/static/html/studio.html
@@ -27,6 +27,20 @@
 
         <li class="field comp-setting-entry metadata_entry ">
           <div class="wrapper-comp-setting">
+            <label class="label setting-label">Create as Team Chat</label>
+             <select class="field-data-control" id="as-team">
+                <option value="false" selected="">
+                  False
+                </option>
+                <option value="true">
+                  True
+                </option>
+              </select>
+          </div>
+        </li>
+
+        <li class="field comp-setting-entry metadata_entry ">
+          <div class="wrapper-comp-setting">
               <p id="message"></p>
           </div>
         </li>

--- a/rocketc/static/js/src/studio_view.js
+++ b/rocketc/static/js/src/studio_view.js
@@ -9,6 +9,16 @@ function StudioViewEdit(runtime, element) {
         if (data["success"]) {
             $("#message").text("Group Created").
             css("color", "green");
+
+            if ($("#as-team").val()==="true"){
+                var name = "(Team Group)"+ $("#group-name").val();
+            }
+            else{
+                var name = $("#group-name").val();
+            }
+            var option = new Option(name, name, true, true);
+            $("#xb-field-edit-default_channel").append(option);
+
         }else{
             $("#message").text(data["error"]).
             css("color", "red");
@@ -22,7 +32,8 @@ function StudioViewEdit(runtime, element) {
         var groupName = $("#group-name").val();
         var description = $("#group-description").val();
         var topic = $("#group-topic").val();
-        var data = {groupName, description, topic};
+        var asTeam = $("#as-team").val() == "true"? true:false;
+        var data = {groupName, description, topic, asTeam};
         $.ajax({
             type: "POST",
             url: createGroup,

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.2.18
+current_version = 0.2.19
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import os
 
 from setuptools import setup
 
-__version__ = '0.2.18'
+__version__ = '0.2.19'
 
 
 def package_data(pkg, roots):


### PR DESCRIPTION
## Description 
This changes allow to create a new channel in studio in order to get the following: 
- When the user creates a channel with the name "example" and "create as team chat" is true, this creates a general channel calls "example".
- In tab default channel-> specific channel,  there will a option with the name "(Team Group) Example"
- If the user selects the option "(Team Group) Example" and makes publish, the student will get on lms the view of rocket chat on "Team_id-Team_name-Example", if the user is not in a team, will get a message.
## Reviewers 
- [x] @jfavellar90 
- [ ] @diegomillan 
