### PR TITLE
Remove unnecessary ajax request when the xblock is not in the team page

### DIFF
--- a/rocketc/static/js/src/rocketc.js
+++ b/rocketc/static/js/src/rocketc.js
@@ -6,6 +6,7 @@ function RocketChatXBlock(runtime, element) {
     });
 
     var setDefaultChannel = runtime.handlerUrl(element, "set_default_channel");
+    var getGroups = runtime.handlerUrl(element, "get_list_of_groups");
 
     if ( $("body").find(".chromeless")[0] && !/Android|iPhone|iPad|iPod|BlackBerry/i.test(navigator.userAgent)){
         $("body").append($(".vert-mod"));
@@ -31,6 +32,7 @@ function RocketChatXBlock(runtime, element) {
             $(".message").text("");
             $(".container-input").hide();
         });
+        loadGroups();
     }
 
     $("#button", element).click(function(eventObject) {
@@ -131,6 +133,4 @@ function RocketChatXBlock(runtime, element) {
         })
     };
 
-    var getGroups = runtime.handlerUrl(element, "get_list_of_groups");
-    loadGroups();
 }

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.2.20
+current_version = 0.2.21
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import os
 
 from setuptools import setup
 
-__version__ = '0.2.20'
+__version__ = '0.2.21'
 
 
 def package_data(pkg, roots):


### PR DESCRIPTION
## Description 
In order to avoid unnecessary ajax request when the xblock is not on the team page, the method load _groups has been relocated 

## Reviewers 
- [ ] @ericfab179 
- [ ] @diegomillan 