### PR TITLE
Fix problem buttons rocket chat for all sites.

### DIFF
--- a/rocketc/static/css/rocketc.css
+++ b/rocketc/static/css/rocketc.css
@@ -35,23 +35,17 @@
   padding: 10px
 }
 
-.rocketc_block #tool-buttons #select-channel {
-  border: 1px solid #bcafaf;
-  border-radius: 3px;
-  box-shadow: inset 0 1px 0 0 #fff;
-  display: inline-block;
-  background-color: #D9D9D9;
-  background-image: linear-gradient(#D9D9D9,#c3b7b7);
-  padding: 3px 18px;
-  text-decoration: none;
-  text-shadow: 0 1px 0 #e6e0e0;
-  font-size: 16px;
-}
-
 #tool-buttons{
   display:none;
 }
 
 .container-input input{
   width: 50%;
+}
+
+#create-channel,
+#leave-channel,
+#select-channel {
+  margin: 0;
+  text-transform: none;
 }

--- a/rocketc/static/html/rocketc.html
+++ b/rocketc/static/html/rocketc.html
@@ -10,9 +10,9 @@
                  </div>
                 <div id="tool-buttons" data-domain="{{public_url_service}}/group/" data-user-id="{{response.userId}}" data-token="{{response.authToken}}" data-default="{{response.default_group}}">
                     <div>
-                        <a class="button" id="create-channel">{% trans "Create New Team Chat" %}</a>
-                        <a class="button" id="leave-channel">{% trans "Leave Chat" %}</a>
-                        <select id="select-channel"></select><br>
+                        <a class="button btn" id="create-channel">{% trans "Create New Team Chat" %}</a>
+                        <a class="button btn" id="leave-channel">{% trans "Leave Chat" %}</a>
+                        <select id="select-channel" class="button btn"></select><br>
                     </div>
                     <div class="container-input create">
                         <form>


### PR DESCRIPTION
@diegomillan 
@ericfab179 

There was a general problem with the select channel on rocket chat for all sites. Styles were made for Pearson but in microsites that have own styles doesn't look good. This is a solution for all sites and was tested for different sites.
CELP
![error-celp-rocket](https://user-images.githubusercontent.com/36944773/46503693-2e24a780-c7f1-11e8-965c-0e0c2a8c7993.png)
![fix-celp-rocket](https://user-images.githubusercontent.com/36944773/46503699-311f9800-c7f1-11e8-8e64-3f8701b56be8.png)
DMSB
![error-dmsb-rocket](https://user-images.githubusercontent.com/36944773/46503714-3e3c8700-c7f1-11e8-9490-818e0cbfb9fb.png)
![fix-dms-rocket](https://user-images.githubusercontent.com/36944773/46503715-409ee100-c7f1-11e8-8272-5d0f574f61e1.png)
PEARSON
![fix-pearson-rocket](https://user-images.githubusercontent.com/36944773/46503720-472d5880-c7f1-11e8-8f73-102bf3157c82.png)

