### PR TITLE
Add condition to verify if "elem" is valid

### DIFF
--- a/rocketc/static/js/src/rocketc.js
+++ b/rocketc/static/js/src/rocketc.js
@@ -161,6 +161,9 @@ function RocketChatXBlock(runtime, element) {
     };
 
     function isScrolledIntoView(elem){
+        if (elem[0]==null){
+            return false;
+        }
         var docViewTop = $(window).scrollTop();
         var docViewBottom = docViewTop + $(window).height();
 


### PR DESCRIPTION
## Description
When the platform loads a subsection with multiple units, this doesn't remove the previous js files when move to another unit in the same subsection, so there is a js error in another unit because "elem" is null, in order to avoid this I have include a condition to verify if elem is valid.
## Reviewers 
- [ ] @ericfab179 
- [x] @diegomillan 