### PR TITLE
PE-356 Rename team channels

### DIFF
--- a/rocketc/api_rocket_chat.py
+++ b/rocketc/api_rocket_chat.py
@@ -146,13 +146,11 @@ class ApiRocketChat(RocketChat):
     def list_all_groups(self, user_id, auth_token, **kwargs):
         """Get a list of groups"""
         url_path = "groups.list"
-        payload = kwargs
         url = "{}{}{}".format(self.server_url, self.API_path, url_path)
 
         headers = {"X-User-Id": user_id, "X-Auth-Token": auth_token}
 
-        response = requests.get(url=url, headers=headers, params=payload)
-        return handle_response("list_all_groups", response, **kwargs)
+        return handle_response("list_all_groups", requests.get(url=url, headers=headers), **kwargs)
 
     def get_groups_history(self, room_id, latest="", oldest="",  # pylint: disable=too-many-arguments
                            count=100, inclusive=False, unreads=False):

--- a/rocketc/rocketc.py
+++ b/rocketc/rocketc.py
@@ -626,7 +626,20 @@ class RocketChatXBlock(XBlock, XBlockWithSettingsMixin, StudioEditableXBlockMixi
 
     @staticmethod
     def _create_team_group_name(team, group_name, course):
+        """
+        This method returns the formated name for given team and group name,
+        in order to ensure a unique name in the rocketchat server.
+        **Example**
+            ** group_name = "Test"
+            ** team = {
+                "name": "team1",
+                "topic": "animals"
+                ......
+            }
+            ** course = "coursev1:edx-c101-2019T2"
 
+            returns "Test(animals/team1)__coursev1:edx-c101-2019T2"
+        """
         team_name, team_topic = generate_team_variables(team)
         return "{}({}/{})__{}".format(group_name, team_topic, team_name, course)
 
@@ -718,11 +731,12 @@ class RocketChatXBlock(XBlock, XBlockWithSettingsMixin, StudioEditableXBlockMixi
         if groups["success"]:
             for group in groups["groups"]:
                 fields = group.get("customFields", {})
-                try:
-                    if (team == fields["team"] and topic == fields["topic"] and self.course_id == fields["course"]):
-                            yield group["name"]
-                except IndexError:
-                    pass
+                if (
+                    team == fields.get("team") and
+                    topic == fields.get("topic") and
+                    self.course_id == fields.get("course")
+                ):
+                    yield group["name"]
 
     def _get_user_messages(self, group_name, latest="", oldest="", count=100):
         """

--- a/rocketc/rocketc.py
+++ b/rocketc/rocketc.py
@@ -628,7 +628,7 @@ class RocketChatXBlock(XBlock, XBlockWithSettingsMixin, StudioEditableXBlockMixi
     def _create_team_group_name(team, group_name, course):
 
         team_name, team_topic = generate_team_variables(team)
-        return "{}__{}__{}__{}".format(group_name, team_name, team_topic, course)
+        return "{}({}/{})__{}".format(group_name, team_topic, team_name, course)
 
     def _remove_user_from_group(self, group_name, user_id, auth_token=None):
         """
@@ -705,11 +705,7 @@ class RocketChatXBlock(XBlock, XBlockWithSettingsMixin, StudioEditableXBlockMixi
             LOG.warn("Invalid data for method get_list_of_groups: %s", data)
             return None
 
-        team = self._get_team(self.user_data["username"])
-
-        kwargs = generate_query_dict(self.course_id, team=team)
-
-        groups = list(self._get_list_groups(user_id, auth_token, **kwargs))
+        groups = list(self._get_list_groups(user_id, auth_token))
         return groups
 
     def _get_list_groups(self, user_id, auth_token, **kwargs):
@@ -718,10 +714,15 @@ class RocketChatXBlock(XBlock, XBlockWithSettingsMixin, StudioEditableXBlockMixi
         """
         api = self.api_rocket_chat
         groups = api.list_all_groups(user_id, auth_token, **kwargs)
+        team, topic = generate_team_variables(self._get_team(self.user_data["username"]))
         if groups["success"]:
-            groups = groups["groups"]
-            for group in groups:
-                yield group["name"]
+            for group in groups["groups"]:
+                fields = group.get("customFields", {})
+                try:
+                    if (team == fields["team"] and topic == fields["topic"] and self.course_id == fields["course"]):
+                            yield group["name"]
+                except IndexError:
+                    pass
 
     def _get_user_messages(self, group_name, latest="", oldest="", count=100):
         """

--- a/rocketc/static/js/src/rocketc.js
+++ b/rocketc/static/js/src/rocketc.js
@@ -145,7 +145,8 @@ function RocketChatXBlock(runtime, element) {
             $("#select-channel").val($("#tool-buttons").attr("data-default"));
         }
         $("#select-channel").change(function(){
-            url = $("#tool-buttons").attr("data-domain") + $("#select-channel").val() +"?layout=embedded";
+            let groupName = $("#select-channel").val().replace("/", "%252F")
+            url = $("#tool-buttons").attr("data-domain") + groupName +"?layout=embedded";
             $("#myframe").attr("src", url);
         });
     };

--- a/rocketc/static/js/src/rocketc.js
+++ b/rocketc/static/js/src/rocketc.js
@@ -145,8 +145,8 @@ function RocketChatXBlock(runtime, element) {
             $("#select-channel").val($("#tool-buttons").attr("data-default"));
         }
         $("#select-channel").change(function(){
-            let groupName = $("#select-channel").val().replace("/", "%252F")
-            url = $("#tool-buttons").attr("data-domain") + groupName +"?layout=embedded";
+            var groupName = $("#select-channel").val().replace("/", "%252F")
+            url = $("#tool-buttons").attr("data-domain") + groupName + "?layout=embedded";
             $("#myframe").attr("src", url);
         });
     };


### PR DESCRIPTION
## Description
- rocket.py  line 631: Change the way how the team names are created [jira ticket](https://proversity.atlassian.net/browse/PE-356)
- rocketc.js line 148-149 remove the character "/" from the name because the url is created in the following way `http://192.168.0.36:3000/group/SecondTeam11(Eng%252Fteam11)__coursev1edxcs1082019?layout=embedded` for the name `SecondTeam11(Eng/team11)__coursev1edxcs1082019`
- Other changes: query parameter support was removed so this changes allow to filter by team, topic and course.