### PR TITLE
PE-518 - Upgrading RocketChat API lib, adding missing dependency.

### DIFF
--- a/rocketc/rocketc.py
+++ b/rocketc/rocketc.py
@@ -268,9 +268,9 @@ class RocketChatXBlock(XBlock, XBlockWithSettingsMixin, StudioEditableXBlockMixi
                 LOG.exception("The admin's settings has not been found")
                 raise
             self._api_rocket_chat = ApiRocketChat(  # pylint: disable=attribute-defined-outside-init
-                user,
-                password,
-                self.server_data["private_url_service"]
+                user=user,
+                password=password,
+                server_url=self.server_data["private_url_service"],
             )
 
             LOG.info("Api rocketChat initialize: %s ", self._api_rocket_chat)

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ setup(
     ],
     install_requires=[
         'XBlock',
+        'rocketchat-API==0.6.34',
     ],
     entry_points={
         'xblock.v1': [


### PR DESCRIPTION
## Description:

This PR updates the RocketChat API to 0.6.34 and adds it to the setup.py install requires.

## Reviewers:

- [ ] @andrey-canon 